### PR TITLE
fix: use `link:` protocol instead of `file:`

### DIFF
--- a/src/system.ts
+++ b/src/system.ts
@@ -30,7 +30,7 @@ function setPathAsVersion(
         if (!successFullEjections.includes(key)) {
             updatedDependencies[key] = dependencies[key] as string;
         } else {
-            updatedDependencies[key] = `file:./ejected/${key}`;
+            updatedDependencies[key] = `link:./ejected/${key}`;
         }
     }
     return updatedDependencies;


### PR DESCRIPTION
It seems that all 3 package managers support the `link:` protocol, which is better fitting than `file:`.